### PR TITLE
fix: exposed ports and target port for prometheus node exporter

### DIFF
--- a/charts/environments/dev/values.yaml
+++ b/charts/environments/dev/values.yaml
@@ -1895,6 +1895,9 @@ prometheus-node-exporter:
     - --collector.filesystem.fs-types-exclude=^(autofs|binfmt_misc|bpf|cgroup2?|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|iso9660|mqueue|nsfs|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|selinuxfs|squashfs|sysfs|tracefs)$
   service:
     portName: http-metrics
+    type: ClusterIP
+    port: 9200
+    targetPort: 9200
   prometheus:
     monitor:
       enabled: true

--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -59,4 +59,4 @@ sources:
 - https://github.com/prometheus-community/helm-charts
 - https://github.com/prometheus-operator/kube-prometheus
 type: application
-version: 48.2.1-dev
+version: 48.2.2-dev

--- a/reports/kubernetes-nsa-cisa-yaml-scan-analysis/helm_results_20230803130412.sarif
+++ b/reports/kubernetes-nsa-cisa-yaml-scan-analysis/helm_results_20230803130412.sarif
@@ -1,0 +1,16 @@
+{
+  "version": "2.1.0",
+  "$schema": "https://json.schemastore.org/sarif-2.1.0-rtm.5.json",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "informationUri": "https://armosec.io",
+          "name": "kubescape",
+          "rules": []
+        }
+      },
+      "results": []
+    }
+  ]
+}


### PR DESCRIPTION
0/3 nodes are available: 1 node(s) didn't have free ports for the requested pod ports. preemption: 0/3 nodes are available: 3 No preemption victims found for incoming pod.